### PR TITLE
Support empty (nor nil) paths

### DIFF
--- a/src/pani/cljs/core.cljs
+++ b/src/pani/cljs/core.cljs
@@ -64,6 +64,11 @@
   ([root korks val]
    (fb-call! #(.set %1 %2) root korks val)))
 
+(defn remove!
+  "Removes the data at this location"
+  ([root] (.remove root))
+  ([root korks] (.remove (walk-root root korks))))
+
 (defn push!
   "Set the value at the given root"
   ([root val]


### PR DESCRIPTION
In particular, find this necessary to `bind` directly to a root.
