### PR TITLE
Generate android.content.Context stub if not in classpath

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -20,6 +20,9 @@
 
   :aliases {"auto-test" ["do" "clean," "cljsbuild" "auto" "test"]}
 
+
+  :aot [pani.clojure.android-stub]
+
   :cljsbuild {:builds [{:id "om-value-changes"
                         :source-paths ["examples/cljs/om-value-changes/src" "src"]
                         :compiler {

--- a/src/pani/clojure/android_stub.clj
+++ b/src/pani/clojure/android_stub.clj
@@ -1,0 +1,9 @@
+;; Avoid reflection-triggered exception when Android SDK not in classpath
+(ns pani.clojure.android-stub
+  (require [clojure.reflect :refer [resolve-class]]))
+
+(defn class-exists? [c]
+  (resolve-class (.getContextClassLoader (Thread/currentThread)) c))
+
+(if-not (class-exists? 'android.content.Context)
+  (gen-class :name "android.content.Context"))


### PR DESCRIPTION
Resolves exception caused reflecting on `com.firebase.client.Firebase` without having the android SDK JARs in your classpath.

This was the "lightest" hack I could come up with, but not sure if it would "just work" transitively when in user projects with Pani as a dependency. Also would need to warn users about needing to remove the stub class (`lein clean` most likely) if deciding to include Android as a dependency later.

@verma thoughts?