### PR TITLE
Various stuff

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,8 +5,8 @@
   :url "http://github.com/verma/pani"
   :author "verma"
   :min-lein-version "2.5.0"
-  :dependencies [[org.clojure/clojure "1.6.0"]
-                 [org.clojure/clojurescript "0.0-2755"]
+  :dependencies [[org.clojure/clojure "1.6.0" :scope "provided"]
+                 [org.clojure/clojurescript "0.0-2755" :scope "provided"]
                  [org.clojure/core.async "0.1.346.0-17112a-alpha"]
                  [com.firebase/firebase-client-jvm "1.1.1"]
 
@@ -14,12 +14,14 @@
   :deploy-repositories [["releases" :clojars]]
 
 
-  :plugins [[lein-cljsbuild "1.0.3"]
-            [com.cemerick/clojurescript.test "0.3.1"]]
+  :plugins [[lein-cljsbuild "1.0.3" :scope "test"]
+            [com.cemerick/clojurescript.test "0.3.1" :scope "test"]]
+
   :profiles {:dev {:dependencies [[om "0.6.4"]]
                    :plugins [[com.cemerick/austin "0.1.7-SNAPSHOT"]]}}
 
-  :aliases {"auto-test" ["do" "clean," "cljsbuild" "auto" "test"]}
+  :aliases {"auto-test" ["do" "clean," "cljsbuild" "auto" "test"]
+            "install"   ["with-profiles" "-dev" "install"]}
 
   :aot [pani.clojure.android-stub]
 


### PR DESCRIPTION
Hey. I'm using parts of pani for a little exploratory project and encountered a few problems, which I tried to fix in my fork.

- Dependencies leak. When people depend on the library they get all sorts of dependencies in. I was able to fix most by adding `:scope "test"` but the `com.cemerick/austin` dep didn't go away without that little `install` alias. I think this might be a bug in Leiningen.

- When the `get-in` function finds  `nil` it tries to put it on the channel and breaks. I'm not sure if this is the right thing to do but It seemed that closing the channel is a suitable alternative. This way consumers know that there was nothing found. Also instead of running `(js->clj :keywordize-keys true)` on the whole Firebase ref I thought it might be a good idea to scope this earlier to keep the required work low.

I might be pushing more changes to this branch so I'd suggest you can leave it open and cherry-pick what you feel is worth it.