### PR TITLE
Miscellaneous things

### DIFF
--- a/src/pani/cljs/core.cljs
+++ b/src/pani/cljs/core.cljs
@@ -133,8 +133,9 @@
   [root korks f & args]
   (let [c (walk-root root korks)
         t (fn [current]
-            (let [newval (apply f (js->clj current :keywordize-keys true) args)]
-              newval))]
+            (let [js-val (js->clj current :keywordize-keys true)
+                  js-new (apply f js-val args)]
+              (clj->js js-new)))]
     (.transaction c t)))
 
 (defn listen<

--- a/test/pani/core_test.cljs
+++ b/test/pani/core_test.cljs
@@ -72,7 +72,7 @@
     (go-loop [m (<! c), r []]
       (let [r (conj r (first m))]
         (when (= (count r) 3)
-          (is (= r [:child_added :child_changed :child_removed]))
+          (is (= r [:child-added :child-changed :child-removed]))
           (pani/disable-listeners!)
           (done))
         (recur (<! c) r)))

--- a/test/pani/core_test.cljs
+++ b/test/pani/core_test.cljs
@@ -115,6 +115,21 @@
     (pani/transact! r [] (comp set keys))
     (js/setTimeout (fn [] (is nil "Timeout, assume Firebase is offline") (done)) 3000)))
 
+(deftest ^:async value-and-get-in-test
+  (let [r (random-root)]
+    (pani/set! r {"a" {"b" {"c" 1}}, "c" 2})
+    (go-loop [c (pani/value r)]
+      (is (= (<! c) {:a {:b {:c 1}}, :c 2}))
+      ;; closed after
+      (is (nil? (<! c)))
+      (done))
+    (go
+      ;; sugared version to take path
+      (is (= {:c 1} (<! (pani/get-in r [:a :b]))))
+      ;; invalid paths return closed channel / deliver nil
+      (is (nil? (<! (pani/get-in r [:a :b :c :d])))))
+    (js/setTimeout (fn [] (is nil "Timeout, assume Firebase is offline") (done)) 3000)))
+
 
 (deftest disable-listeners!-test
   (let [r (random-root)]


### PR DESCRIPTION
#### Overview

1. Decompose `get-in` to `value` + `walk-root`
2. Always close `value` channels once work is done
3. Add tests for `value` and `get-in`, and an extra test for `transact` with non-primitive data
4. Fix regression around `transact` behaviour on non-primitive data 
5. Highlight some unintuitive behaviour in tests
6. DRY up `listen<` somewhat, and convert `:under_keys` to `:kebab-keys` (breaking change for `0.0.4`)

@martinklepsch `(comp ..)` for the win, as discussed ;)

@verma looking at https://github.com/verma/pani/blob/df8b6a0a10f3dbcc4ef1351f1336dd56a65b6715/test/pani/core_test.cljs#L107-L110, do you think we should do something about this?

Possible solution:

Prepend `clj->js` with a tree walking phase, turning everything besides maps, vectors, primitives and keywords-in-map-entry into edn, and append `js->clj` with a edn hydration step.

And perhaps a dynamic variable to turn this step off for users that want to avoid the (unmeasured) overhead involved.

Also not sure if "maps, vectors, primitives and keywords-in-map-entry" are the full exclusion list.

(also weigh in if you're against [6])